### PR TITLE
Fix npm scripts, Fixes #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ First usage:
     npm install
     npm run init
 
+And just run:
+
+    npm start
+
 The `init` script ensures you got all the configuration needed for the project.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # authorization-server
 An OAuth2 authorization server supporting OpenID Connect
+
+# Usage
+First usage:
+
+    git clone https://github.com/shakedmanes/authorization-server.git
+    npm install
+    npm run init
+
+The `init` script ensures you got all the configuration needed for the project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,6 +2768,12 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
     "inversify": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.13.0.tgz",
@@ -3833,6 +3839,15 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.8.1"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
@@ -4077,6 +4092,17 @@
         "array-map": "0.0.0",
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "An OAuth2 authorization server supporting OpenID Connect",
   "main": "app.js",
   "scripts": {
+    "init": "npm run build && npm run generate-certs && npm run generate-env",
+    "start": "npm run build && npm run serve",
     "start-watch": "npm run build && nodemon -e ts -w ./src -i ./src/**/*.spec.ts -x npm run watch-serve",
     "serve": "node dist/server.js",
     "watch-serve": "ts-node --inspect src/server.ts",
@@ -11,6 +13,8 @@
     "build-watch": "tsc -w",
     "tslint-config": "tslint -c tslint.json -p tsconfig.json",
     "copy-files": "node ./scripts/copy_files.js",
+    "generate-certs": "node ./scripts/generate_certs.js",
+    "generate-env": "node ./scripts/generate_env.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -75,6 +79,7 @@
     "@types/passport-strategy": "^0.2.35",
     "cpx": "^1.5.0",
     "nodemon": "^1.18.3",
+    "shelljs": "^0.8.2",
     "ts-node": "^7.0.0",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.9.2",

--- a/scripts/copy_files.js
+++ b/scripts/copy_files.js
@@ -18,10 +18,16 @@ function copyFolderRecursiveSync(source, target) {
   let files = [];
 
   // Check if folder needs to be created or integrated
-  let targetFolder = path.join(target, path.basename(source));  
-  if (!fs.existsSync(targetFolder)) {
-      fs.mkdirSync(targetFolder);
-  }
+  let targetFolder = path.join(target, path.basename(source));
+
+  // Create any subfolders needed if not already exists
+  targetFolder.split(path.sep).reduce((currentPath, folder) => {
+    currentPath += folder + path.sep;
+    if (!fs.existsSync(currentPath)) {
+        fs.mkdirSync(currentPath);
+    }
+    return currentPath;
+  }, '');
 
   // Copy
   if (fs.lstatSync(source).isDirectory()) {

--- a/scripts/generate_certs.js
+++ b/scripts/generate_certs.js
@@ -1,0 +1,14 @@
+const shell = require('shelljs');
+
+function generateCertificates(target) {  
+
+  // Move to the target folder and create the certificates
+  shell.mkdir('-p', target);
+  shell.cd(target);
+  shell.exec(`C:\\"Program Files"\\Git\\mingw64\\bin\\openssl.exe genrsa -out privatekey.pem 2048`);
+  shell.exec(`C:\\"Program Files"\\Git\\mingw64\\bin\\openssl.exe req -new -key privatekey.pem -out certrequest.csr -days 1024 -nodes -subj "/C=US/ST=New York/L=New York/O=Bla Bla/OU=alB alB/CN=authorization-server"`);
+  shell.exec(`C:\\"Program Files"\\Git\\mingw64\\bin\\openssl.exe x509 -req -in certrequest.csr -signkey privatekey.pem -out certificate.pem`);
+  shell.rm('certrequest.csr');
+}
+
+generateCertificates('src/certs');

--- a/scripts/generate_env.js
+++ b/scripts/generate_env.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+function generateEnvFile(port, nodeEnv) {
+  // Creates .env file for configuration
+  fs.writeFileSync('.env', `PORT=${port}\r\nNODE_ENV=${nodeEnv}`);
+}
+
+generateEnvFile(1337, 'dev');


### PR DESCRIPTION
### PR Includes:

- Fix npm scripts erros
- Add `start` script for simplicity
- Add `init` script for the first clone of the repository and configurations
- Add generate certifications NodeJS script for generating certifications 
- Add generate `.env` file NodeJS script for generating `.env` file