### PR TITLE
Fix authorization code flow bad request error

### DIFF
--- a/src/accessToken/accessToken.model.ts
+++ b/src/accessToken/accessToken.model.ts
@@ -47,6 +47,15 @@ const accessTokenSchema = new Schema({
 // Ensures there's only one token for user in specific client app
 accessTokenSchema.index({ clientId: 1, userId: 1 }, { unique: true });
 
+// Construct better error handling for errors from mongo server
+accessTokenSchema.post('save', (err, doc, next) => {
+  if (err.name === 'MongoError' && err.code === 11000) {
+    err.message = `There's already token for the client and the user.`;
+  }
+
+  next(err);
+});
+
 /**
  * ############ FOR FUTURE VERSIONS ONLY ############
  * We can decide for each client, how much he want the user to have a token.

--- a/src/authCode/authCode.model.ts
+++ b/src/authCode/authCode.model.ts
@@ -43,6 +43,15 @@ const authCodeSchema = new Schema({
 // Ensures there's only one code for client and user combination
 authCodeSchema.index({ clientId: 1, userId: 1 }, { unique: true });
 
+// Construct better error handling for errors from mongo server
+authCodeSchema.post('save', (err, doc, next) => {
+  if (err.name === 'MongoError' && err.code === 11000) {
+    err.message = `There's already authorization code for the client and the user.`;
+  }
+
+  next(err);
+});
+
 // TODO: Implement proper exception handling for this throwed error
 // Checking if redirectUri specified is in the redirect uris of the client model
 authCodeSchema.pre<IAuthCode>('validate', async function () {

--- a/src/utils/error.handler.ts
+++ b/src/utils/error.handler.ts
@@ -10,7 +10,7 @@ export function errorHandler(error: any, req: Request, res: Response, next: Next
   // Authentication error caused by passport strategy
   if (error.name === 'AuthenticationError') {
     return res.status(error.status).send({
-      message: req.session ? req.session.messages[0] : error.name,
+      message: req.session ? req.session.messages[req.session.messages.length - 1] : error.name,
     });
   }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -32,6 +32,12 @@ export class InvalidParameter extends BaseError {
   }
 }
 
+export class BadRequest extends BaseError {
+  constructor(message?: string) {
+    super(message || 'Bad Request', 400);
+  }
+}
+
 export class InternalServerError extends BaseError {
   constructor(message?: string) {
     super(message || 'Internal Server Error', 500);


### PR DESCRIPTION
### What is done in this PR:

- Validating before creating `authorization code`, if there's already generated token, and avoid duplicate tokens.
- Better error message when there's `E11000` mongo error (duplicate key) in `token`s and `authorization code`s.