### PR TITLE
Fixing client credentials flow

### DIFF
--- a/src/accessToken/accessToken.model.ts
+++ b/src/accessToken/accessToken.model.ts
@@ -48,13 +48,13 @@ const accessTokenSchema = new Schema({
   },
 });
 
-// Ensures there's only one token for user in specific client app
-accessTokenSchema.index({ clientId: 1, userId: 1 }, { unique: true });
+// Ensures there's only one token for user in specific client app and audience
+accessTokenSchema.index({ clientId: 1, userId: 1, audience: 1 }, { unique: true });
 
 // Construct better error handling for errors from mongo server
 accessTokenSchema.post('save', (err, doc, next) => {
   if (err.name === 'MongoError' && err.code === 11000) {
-    err.message = `There's already token for the client and the user.`;
+    err.message = `There's already token for the client and the user and the audience.`;
   }
 
   next(err);

--- a/src/oauth2/oauth2.controller.ts
+++ b/src/oauth2/oauth2.controller.ts
@@ -232,11 +232,14 @@ server.exchange(oauth2orize.exchange.clientCredentials(
   {},
   async (client: IClient, scope, body, done) => {
 
+    // TODO: Uncomment the following code when scopes feature is ready.
+
     // If the client doesn't have actually scopes to grant authorization on
-    if (client.scopes.length === 0) {
-      const errorMessage = `Client doesn't support client_credentials due incomplete scopes value`;
-      return done(new BadRequest(errorMessage));
-    }
+    // if (client.scopes.length === 0) {
+    // tslint:disable-next-line:max-line-length
+    //   const errorMessage = `Client doesn't support client_credentials due incomplete scopes value`;
+    //   return done(new BadRequest(errorMessage));
+    // }
 
     // Check if audience specified
     if (!body.audience) {


### PR DESCRIPTION
Fixing client credentials flow, allow clients without scopes, add 'audience' index on access token model